### PR TITLE
chore: Typo Correction and Documentation Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export TWITTER_CLIENT_SECRET=""
 Install the following:
 
 * `cargo install cargo-leptos --version=0.2.20`
-* `cargo install sqlx-cli --verison=0.7.3`
+* `cargo install sqlx-cli --version=0.7.3`
 * `cargo install wasm-pack --version=0.12.1`
 * `rustup target add wasm32-unknown-unknown`
 * `cargo install bunyan`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,7 +53,7 @@ severity issues.
 
 ### For example:
 
-* Disclosing the title of issues in private repositories, which should be be inaccessible
+* Disclosing the title of issues in private repositories, which should be inaccessible
 * Injecting attacker controlled content into BlockMesh Network.com (XSS) but not bypassing CSP or executing sensitive
 * Actions with another user’s session
 * Bypassing CSRF validation for low risk actions, such as starring a repository or unsubscribing from a mailing list


### PR DESCRIPTION
Corrected Typos:

- In the installation instructions, corrected the typo in the sqlx-cli installation command from `--verison` to `--version`.
- In the security documentation, corrected the duplicate word "be" in the example for medium severity issues from `which should be be inaccessible` to `which should be inaccessible`.