### PR TITLE
build: update upload-artifact to v4

### DIFF
--- a/.github/workflows/publish-chrome-extension.yml
+++ b/.github/workflows/publish-chrome-extension.yml
@@ -92,7 +92,7 @@ jobs:
             exit 1
           fi
       - name: Archive chrome-extension artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-${{ github.sha }}
           path: chrome-extension-${{ github.sha }}.zip


### PR DESCRIPTION
Maintenance update: migrating to upload-artifact@v4 for improved artifact handling. Pure maintenance, behavior unchanged. See the [v4.6.2 release](https://github.com/actions/upload-artifact/releases) for details.