### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y  \
           librsvg2-dev patchelf build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y  \
             librsvg2-dev patchelf build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,7 +32,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Get tag"
         id: "pkg-version"
         shell: "bash"
@@ -45,7 +45,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Create release"
         uses: "taiki-e/create-gh-release-action@v1"
         with:

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -30,7 +30,7 @@ jobs:
           "cloudflare-captcha-page"
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,7 +19,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/publish-chrome-extension.yml
+++ b/.github/workflows/publish-chrome-extension.yml
@@ -20,7 +20,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/release-arm.yml
+++ b/.github/workflows/release-arm.yml
@@ -34,7 +34,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -113,7 +113,7 @@ jobs:
       group: "arm"
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Log in to Docker Hub"
         uses: "docker/login-action@v3"
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -33,7 +33,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -106,7 +106,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -95,7 +95,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -137,7 +137,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -176,7 +176,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -215,7 +215,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -254,7 +254,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -293,7 +293,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -332,7 +332,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -371,7 +371,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -410,7 +410,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -449,7 +449,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -488,7 +488,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -527,7 +527,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Install deps"
         run: |
           sudo apt-get update
@@ -574,7 +574,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Create tag"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -21,7 +21,7 @@ jobs:
       pkg-version: ${{ steps.pkg-version.outputs.PKG_VERSION }}
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUSTC_VERSION }}
@@ -58,7 +58,7 @@ jobs:
             target: "x86_64-pc-windows-msvc"
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/update-tailwind-css.yml
+++ b/.github/workflows/update-tailwind-css.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0